### PR TITLE
Python interface build/run fixes

### DIFF
--- a/interfaces/PyNomad/nomadCySimpleInterface.cpp
+++ b/interfaces/PyNomad/nomadCySimpleInterface.cpp
@@ -420,7 +420,7 @@ static int runNomad(Callback cb,
 
         // Set cbL to NULL if blocks are not used.
         // Set cb to NULL if blocks are used.
-        if (allParams->getEvaluatorControlParams()->getAttributeValue<size_t>("BB_MAX_BLOCK_SIZE") > 1)
+        if (allParams->getEvaluatorControlGlobalParams()->getAttributeValue<size_t>("BB_MAX_BLOCK_SIZE") > 1)
         {
             // Using blocks
             cb = nullptr;

--- a/interfaces/PyNomad/nomadCySimpleInterface.cpp
+++ b/interfaces/PyNomad/nomadCySimpleInterface.cpp
@@ -52,6 +52,7 @@
 #include "Math/RNG.hpp"
 #include "Nomad/nomad.hpp"
 #include "Param/AllParameters.hpp"
+#include "Cache/CacheBase.hpp"
 
 #include <Python.h>
 #include <signal.h>
@@ -441,8 +442,8 @@ static int runNomad(Callback cb,
 
         // Set the best feasible and best infeasible solutions
         std::vector<NOMAD::EvalPoint> evalPointFeasList, evalPointInfList;
-        auto nbFeas = NOMAD::CacheBase::getInstance()->findBestFeas(evalPointFeasList, NOMAD::Point(), NOMAD::EvalType::BB);
-        auto nbInf  = NOMAD::CacheBase::getInstance()->findBestInf(evalPointInfList, NOMAD::INF, NOMAD::Point(), NOMAD::EvalType::BB);
+        auto nbFeas = NOMAD::CacheBase::getInstance()->findBestFeas(evalPointFeasList, NOMAD::Point(), NOMAD::EvalType::BB, nullptr);
+        auto nbInf  = NOMAD::CacheBase::getInstance()->findBestInf(evalPointInfList, NOMAD::INF, NOMAD::Point(), NOMAD::EvalType::BB, nullptr);
 
         if (nbInf > 0)
         {

--- a/interfaces/PyNomad/runTest.py
+++ b/interfaces/PyNomad/runTest.py
@@ -14,5 +14,5 @@ ub=[]
 
 params = ["BB_OUTPUT_TYPE OBJ", "MAX_BB_EVAL 100", "UPPER_BOUND * 1", "DISPLAY_DEGREE 2", "DISPLAY_ALL_EVAL false", "DISPLAY_STATS BBE THREAD_NUM OBJ"] 
 
-[ x_return, f_return, h_return, nb_evals, nb_iters, stopflag ] = PyNomad.optimize(bb, x0, lb, ub, params)
+x_return, f_return, h_return, nb_evals, nb_iters, stopflag = PyNomad.optimize(bb, x0, lb, ub, params)
 print ("\n NOMAD outputs \n X_sol={} \n F_sol={} \n H_sol={} \n NB_evals={} \n NB_iters={} \n".format(x_return,f_return,h_return,nb_evals,nb_iters))

--- a/interfaces/PyNomad/runTest_BlockEval.py
+++ b/interfaces/PyNomad/runTest_BlockEval.py
@@ -13,11 +13,11 @@ def bb_block(block):
             # eval each point
             x = block.get_x(k)
             dim = x.size()
-            f = sum([x.get_coord(i)**2 for i in range(dim)])    
+            f = sum([x.get_coord(i)**2 for i in range(dim)])
             x.setBBO(str(f).encode("UTF-8"), B"OBJ")
             evalOk[k] = True
-    except:
-        print("Unexpected error in bb_block()", sys.exc_info()[0])
+    except Exception as e:
+        print("Unexpected error in bb_block()", str(e))
         return 0
     return evalOk # list where 1 is success, 0 is a failed evaluation
 
@@ -27,7 +27,7 @@ ub=[]
 
 params =  ["BB_OUTPUT_TYPE OBJ", "MAX_BB_EVAL 100", "UPPER_BOUND * 1"]
 params += ["DISPLAY_DEGREE 2", "DISPLAY_STATS BBE BLK_SIZE OBJ", "DISPLAY_ALL_EVAL false"]
-params += ["NB_THREADS_OPENMP 1", "BB_MAX_BLOCK_SIZE 4"] 
+params += ["NB_THREADS_OPENMP 1", "BB_MAX_BLOCK_SIZE 4"]
 
-[ x_return, f_return, h_return, nb_evals, nb_iters, stopflag ] = PyNomad.optimize(bb_block, x0, lb, ub, params)
+x_return, f_return, h_return, nb_evals, nb_iters, stopflag = PyNomad.optimize(bb_block, x0, lb, ub, params)
 print ("\n NOMAD outputs \n X_sol={} \n F_sol={} \n H_sol={} \n NB_evals={} \n NB_iters={} \n".format(x_return,f_return,h_return,nb_evals,nb_iters))

--- a/interfaces/PyNomad/setup_PyNomad.py
+++ b/interfaces/PyNomad/setup_PyNomad.py
@@ -50,9 +50,11 @@ if sys.platform == "darwin":
      os.environ["CXX"] = "g++"
 
 setup(
+    name='PyNomad',
+
     ext_modules = cythonize(Extension(
            "PyNomad", # extension name
-           sources = ["PyNomad.pyx", "nomadCySimpleInterface.cpp"], # Cython source and interface
+           sources = ["PyNomad.pyx"], # Cython source and interface
            include_dirs = os_include_dirs,
            extra_compile_args = compile_args,
            extra_link_args = link_args,


### PR DESCRIPTION
Building and running the PyNomad interface did not work for me, using 4.0.0 beta 2. This PR fixes a couple of issues:

- `NOMAD::CacheBase::getInstance()` interface change (fix follows MainStep.cpp)
- `name='PyNomad'` needed for setuptools (otherwise defaults to `UNKNOWN` for the egg info)
- drop `nomadCySimpleInterface.cpp` from sources (is already `#include`d in generated `PyNomad.cpp`, leading to duplicated (`static`, so mostly harmless) code)
- `BB_MAX_BLOCK_SIZE` was moved to ControlGlobalParams (the lookup as-is always fails, even if set)

In the python tests, I changed the exception printing to have a clear error message (needed for debugging the above lookup problem), removed some whitespace, and the unnecessary repacking/unpacking into lists of return values.

With these changes, the Python interface and its tests build and run for me with 4.0.0 beta 2.