### PR TITLE
port to Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,13 @@ elseif (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
         message(FATAL_ERROR "Clang version has not been tested for Nomad!")
     endif()
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    # require at least 15.0 (MSVC 2017) for C++14 support
+    if (MSVC_TOOLSET_VERSION VERSION_LESS 141)
+        message(FATAL_ERROR "MSVC version ${CMAKE_CXX_COMPILER_VERSION} has not been tested for Nomad!")
+    endif()
 else()
-    message(WARNING "You are using an unsupported compiler! Compilation has only been tested with Clang and GCC.")
+    message(WARNING "You are using an unsupported compiler! Compilation has only been tested with Clang, GCC, and MSVC.")
 endif()
 
 #options

--- a/examples/basic/library/example1/CMakeLists.txt
+++ b/examples/basic/library/example1/CMakeLists.txt
@@ -3,7 +3,9 @@ add_executable(example1_lib.exe example1_lib.cpp )
 target_include_directories(example1_lib.exe PRIVATE
     ${CMAKE_SOURCE_DIR}/src)
 
-set_target_properties(example1_lib.exe PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set_target_properties(example1_lib.exe
+    PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+               SUFFIX "")
 
 
 if(OpenMP_CXX_FOUND)

--- a/examples/basic/library/example2/CMakeLists.txt
+++ b/examples/basic/library/example2/CMakeLists.txt
@@ -3,7 +3,9 @@ add_executable(example2_lib.exe example2_lib.cpp )
 target_include_directories(example2_lib.exe PRIVATE
     ${CMAKE_SOURCE_DIR}/src)
 
-set_target_properties(example2_lib.exe PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set_target_properties(example2_lib.exe
+    PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+               SUFFIX "")
 
 
 if(OpenMP_CXX_FOUND)

--- a/examples/basic/library/example3/CMakeLists.txt
+++ b/examples/basic/library/example3/CMakeLists.txt
@@ -3,7 +3,9 @@ add_executable(example3_lib.exe example3_lib.cpp )
 target_include_directories(example3_lib.exe PRIVATE
     ${CMAKE_SOURCE_DIR}/src)
 
-set_target_properties(example3_lib.exe PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set_target_properties(example3_lib.exe
+    PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+               SUFFIX "")
 
 
 if(OpenMP_CXX_FOUND)

--- a/ext/sgtelib/CMakeLists.txt
+++ b/ext/sgtelib/CMakeLists.txt
@@ -29,8 +29,13 @@ elseif (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
         message(FATAL_ERROR "Clang version has not been tested for Nomad!")
     endif()
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    # require at least 15.0 (MSVC 2017) for C++14 support
+    if (MSVC_TOOLSET_VERSION VERSION_LESS 141)
+        message(FATAL_ERROR "MSVC version ${CMAKE_CXX_COMPILER_VERSION} has not been tested for Nomad!")
+    endif()
 else()
-    message(WARNING "You are using an unsupported compiler! Compilation has only been tested with Clang and GCC.")
+    message(WARNING "You are using an unsupported compiler! Compilation has only been tested with Clang, GCC, and MSVC.")
 endif()
 
 # require c++14
@@ -97,6 +102,11 @@ target_include_directories(sgtelib PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/sgtelib>
     )
+
+# export symbols on Windows
+if (WIN32)
+    target_compile_definitions(sgtelib PRIVATE -DDLL_EXPORTS)
+endif()
 
 ## build executable sgtelib_main
 #add_executable(sgtelib_main ${SGTELIB_SOURCES})

--- a/ext/sgtelib/src/Surrogate_RBF.cpp
+++ b/ext/sgtelib/src/Surrogate_RBF.cpp
@@ -101,7 +101,7 @@ bool SGTELIB::Surrogate_RBF::init_private ( void ) {
                                                    _param.get_distance_type());
     // select_greedy() might return a set with less than _qrbf points
     // in which case _qrbf is modified
-    if (_selected_kernel.size() < _qrbf){
+    if ((int)_selected_kernel.size() < _qrbf){
       _qrbf = _selected_kernel.size();
     }     
   }

--- a/ext/sgtelib/src/Surrogate_Utils.hpp
+++ b/ext/sgtelib/src/Surrogate_Utils.hpp
@@ -32,7 +32,9 @@
 #include <sys/stat.h>
 
 // Helpful for compilaton on some platforms
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 // CASE Visual Studio C++ compiler
 #ifdef _MSC_VER

--- a/src/Algos/Algorithm.hpp
+++ b/src/Algos/Algorithm.hpp
@@ -89,10 +89,6 @@ protected:
     double _totalCPUAlgoTime;
 #endif // TIME_STATS
 
-#ifdef _OPENMP
-    static omp_lock_t _algoCommentLock;
-#endif // _OPENMP
-
 public:
     /// Constructor
     /**

--- a/src/Algos/EvcInterface.hpp
+++ b/src/Algos/EvcInterface.hpp
@@ -47,6 +47,7 @@
 #ifndef __NOMAD400_EVCINTERFACE__
 #define __NOMAD400_EVCINTERFACE__
 
+#include "../nomad_platform.hpp"
 #include "../Algos/Step.hpp"
 #include "../Eval/EvaluatorControl.hpp"
 
@@ -63,7 +64,7 @@ private:
     const Step* _step;      ///< Step that uses the EvaluatorControl
     Point _fixedVariable;   ///< Full dimension point including fixed variables
 
-    static std::shared_ptr<EvaluatorControl> _evaluatorControl; ///< Static EvaluatorControl
+    DLL_ALGO_API static std::shared_ptr<EvaluatorControl> _evaluatorControl; ///< Static EvaluatorControl
 
 public:
     /// Constructor

--- a/src/Algos/IterationUtils.cpp
+++ b/src/Algos/IterationUtils.cpp
@@ -109,7 +109,7 @@ bool NOMAD::IterationUtils::snapPointToBoundsAndProjectOnMesh(
     {
         fixedVariable = NOMAD::SubproblemManager::getInstance()->getSubFixedVariable(_parentStep);
     }
-    catch (NOMAD::Exception &e)
+    catch (NOMAD::Exception &/*e*/)
     {
         if (nullptr != evalPoint.getPointFrom())
         {

--- a/src/Algos/Mads/MadsInitialization.cpp
+++ b/src/Algos/Mads/MadsInitialization.cpp
@@ -52,8 +52,7 @@
 #include "../../Algos/Mads/MadsInitialization.hpp"
 #include "../../Cache/CacheBase.hpp"
 #include "../../Output/OutputQueue.hpp"
-
-#include <unistd.h> // For usleep
+#include "../../Util/MicroSleep.hpp"
 
 void NOMAD::MadsInitialization::init()
 {

--- a/src/Algos/Mads/MegaSearchPoll.cpp
+++ b/src/Algos/Mads/MegaSearchPoll.cpp
@@ -44,6 +44,7 @@
 /*  You can find information on the NOMAD software at www.gerad.ca/nomad           */
 /*---------------------------------------------------------------------------------*/
 
+#include "../../nomad_platform.hpp"
 #include "../../Algos/EvcInterface.hpp"
 #include "../../Algos/Mads/MegaSearchPoll.hpp"
 #include "../../Algos/Mads/MadsMegaIteration.hpp"
@@ -100,7 +101,7 @@ void NOMAD::MegaSearchPoll::endImp()
 // Generate new points to evaluate from Poll and Search
 void NOMAD::MegaSearchPoll::generateTrialPoints()
 {
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, true);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, true);
     OUTPUT_INFO_START
     AddOutputInfo("Generate points for " + _name, true, false);
     OUTPUT_INFO_END

--- a/src/Algos/Mads/Poll.cpp
+++ b/src/Algos/Mads/Poll.cpp
@@ -44,6 +44,7 @@
 /*  You can find information on the NOMAD software at www.gerad.ca/nomad           */
 /*---------------------------------------------------------------------------------*/
 
+#include "../../nomad_platform.hpp"
 #include "../../Algos/AlgoStopReasons.hpp"
 #include "../../Algos/Mads/DoublePollMethod.hpp"
 #include "../../Algos/Mads/NP1UniPollMethod.hpp"
@@ -88,7 +89,7 @@ void NOMAD::Poll::init()
 void NOMAD::Poll::startImp()
 {
     // Sanity check.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 }
 
 
@@ -98,7 +99,7 @@ bool NOMAD::Poll::runImp()
     std::string s;
 
     // Sanity check. The runImp function should be called only when trial points are generated and evaluated for each search method separately.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 
     // Go through all poll methods to generate points.
     OUTPUT_DEBUG_START
@@ -142,7 +143,7 @@ bool NOMAD::Poll::runImp()
 void NOMAD::Poll::endImp()
 {
     // Sanity check. The endImp function should be called only when trial points are generated and evaluated for each search method separately.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 
     // Compute hMax and update Barrier.
     postProcessing();

--- a/src/Algos/Mads/Search.cpp
+++ b/src/Algos/Mads/Search.cpp
@@ -44,6 +44,7 @@
 /*  You can find information on the NOMAD software at www.gerad.ca/nomad           */
 /*---------------------------------------------------------------------------------*/
 
+#include "../../nomad_platform.hpp"
 #include "../../Algos/EvcInterface.hpp"
 #include "../../Algos/Mads/Search.hpp"
 #include "../../Algos/Mads/QuadSearchMethod.hpp"
@@ -100,7 +101,7 @@ void NOMAD::Search::init()
 void NOMAD::Search::startImp()
 {
    // Sanity check.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 
 }
 
@@ -111,7 +112,7 @@ bool NOMAD::Search::runImp()
     std::string s;
 
     // Sanity check. The runImp function should be called only when trial points are generated and evaluated for each search method separately.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 
     if (!isEnabled())
     {
@@ -183,7 +184,7 @@ bool NOMAD::Search::runImp()
 void NOMAD::Search::endImp()
 {
     // Sanity check. The endImp function should be called only when trial points are generated and evaluated for each search method separately.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 
     if (!isEnabled())
     {
@@ -204,7 +205,7 @@ void NOMAD::Search::endImp()
 void NOMAD::Search::generateTrialPoints()
 {
     // Sanity check. The generateTrialPoints function should be called only when trial points are generated for all each search method. After that all trials points evaluated at once.
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, true);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, true);
 
     for (auto searchMethod : _searchMethods)
     {

--- a/src/Algos/NelderMead/NMIteration.cpp
+++ b/src/Algos/NelderMead/NMIteration.cpp
@@ -46,6 +46,7 @@
 
 #include <algorithm>    // For std::merge and std::unique
 
+#include "../../nomad_platform.hpp"
 #include "../../Algos/AlgoStopReasons.hpp"
 #include "../../Algos/NelderMead/NMIteration.hpp"
 #include "../../Algos/NelderMead/NMUpdate.hpp"
@@ -91,7 +92,7 @@ bool NOMAD::NMIteration::runImp()
     // Sequential run of NM steps among INITIAL, ( REFLECT, EXPANSION, INSIDE_CONTRACTION, OUTSIDE_CONTRACTION ), SHRINK
 
     // NMIteration cannot generate all points before evaluation
-    verifyGenerateAllPointsBeforeEval(__PRETTY_FUNCTION__, false);
+    verifyGenerateAllPointsBeforeEval(NOMAD_PRETTY_FUNCTION, false);
 
     bool iterationSuccess = false;
 

--- a/src/Algos/PSDMads/PSDMads.cpp
+++ b/src/Algos/PSDMads/PSDMads.cpp
@@ -52,8 +52,7 @@
 #include "../../Algos/PSDMads/PSDMadsMegaIteration.hpp"
 #include "../../Cache/CacheBase.hpp"
 #include "../../Output/OutputQueue.hpp"
-
-#include <unistd.h> // For usleep
+#include "../../Util/MicroSleep.hpp"
 
 // Initialize static lock variable
 omp_lock_t NOMAD::PSDMads::_psdMadsLock;

--- a/src/Algos/QuadModel/QuadModelEvaluator.hpp
+++ b/src/Algos/QuadModel/QuadModelEvaluator.hpp
@@ -46,6 +46,7 @@
 #ifndef __NOMAD400_QUAD_MODEL_EVALUATION__
 #define __NOMAD400_QUAD_MODEL_EVALUATION__
 
+#include "../../nomad_platform.hpp"
 #include "../../Eval/Evaluator.hpp"
 #include "../../Output/OutputInfo.hpp"
 #include "../../../ext/sgtelib/src/Surrogate.hpp"
@@ -86,7 +87,7 @@ public:
      Points for evaluations are given in a block. Sgtelib models handle the points as a matrix and return a matrix for outputs.
      */
     std::vector<bool> eval_block(Block &block,
-                                 const Double &hMax  __attribute__((unused)),
+                                 const Double &NOMAD_UNUSED(hMax),
                                  std::vector<bool> &countEval) const override;
 
 private:

--- a/src/Algos/SgtelibModel/SgtelibModelEvaluator.hpp
+++ b/src/Algos/SgtelibModel/SgtelibModelEvaluator.hpp
@@ -47,6 +47,7 @@
 #ifndef __NOMAD400_SGTELIB_MODEL_EVALUATION__
 #define __NOMAD400_SGTELIB_MODEL_EVALUATION__
 
+#include "../../nomad_platform.hpp"
 #include "../../Algos/SgtelibModel/SgtelibModel.hpp"
 #include "../../Eval/Evaluator.hpp"
 #include "../../Type/SgtelibModelFeasibilityType.hpp"
@@ -78,7 +79,7 @@ public:
     virtual ~SgtelibModelEvaluator();
 
     bool eval_x(EvalPoint &x,
-                const Double &hMax __attribute__((unused)),
+                const Double &NOMAD_UNUSED(hMax),
                 bool &countEval) const override;
 
 private:

--- a/src/Algos/Step.hpp
+++ b/src/Algos/Step.hpp
@@ -47,6 +47,7 @@
 #ifndef __NOMAD400_STEP__
 #define __NOMAD400_STEP__
 
+#include "../nomad_platform.hpp"
 #include "../Algos/MeshBase.hpp"
 #include "../Eval/Barrier.hpp"
 #include "../Output/OutputInfo.hpp"
@@ -375,8 +376,8 @@ private:
     void init();
 
     // Default callbacks. They do nothing.
-    static void defaultStepEnd(const Step& step  __attribute__((unused)), bool &stop) { stop = false; }
-    static void defaultHotRestart(std::vector<std::string>& paramLines  __attribute__((unused))) {};
+    static void defaultStepEnd(const Step& NOMAD_UNUSED(step), bool &stop) { stop = false; }
+    static void defaultHotRestart(std::vector<std::string>& NOMAD_UNUSED(paramLines)) {};
 
     /**
      Default task always executed when start() is called

--- a/src/Algos/SubproblemManager.cpp
+++ b/src/Algos/SubproblemManager.cpp
@@ -158,7 +158,7 @@ const NOMAD::Subproblem& NOMAD::SubproblemManager::getSubproblem(const NOMAD::St
 #endif // _OPENMP
         return sub;
     }
-    catch (const std::out_of_range& oor)
+    catch (const std::out_of_range& /*oor*/)
     {
         std::cerr << "Error: Subproblem not found for Algorithm " << algo->getName() << std::endl;
     }

--- a/src/Attribute/WriteAttributeDefinitionFile.cpp
+++ b/src/Attribute/WriteAttributeDefinitionFile.cpp
@@ -49,6 +49,7 @@
 // to be modified.
 
 #include <algorithm>    // for for_each
+#include <cctype>       // for toupper, isdigit
 #include <stdio.h>
 #include <stdlib.h>
 #include <fstream>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -478,6 +478,11 @@ add_custom_command(
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+# export all symbols on Windows
+if (WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 # Utils
 add_library (nomadUtils SHARED ${MATH_SOURCES} ${OUTPUT_SOURCES} ${PARAM_SOURCES} ${TYPE_SOURCES} ${UTIL_SOURCES} ${ATTRIBUTE_HEADERS})
 target_include_directories(nomadUtils PUBLIC
@@ -487,6 +492,9 @@ target_include_directories(nomadUtils PUBLIC
 )
 if(OpenMP_CXX_FOUND)
     target_link_libraries(nomadUtils PUBLIC OpenMP::OpenMP_CXX)
+endif()
+if (WIN32)
+    target_compile_definitions(nomadUtils PRIVATE -DDLL_UTIL_EXPORTS)
 endif()
 
 # Evals
@@ -498,6 +506,9 @@ target_include_directories(nomadEval PUBLIC
 target_link_libraries(nomadEval PUBLIC nomadUtils)
 if(OpenMP_CXX_FOUND)
     target_link_libraries(nomadEval PUBLIC OpenMP::OpenMP_CXX)
+endif()
+if (WIN32)
+    target_compile_definitions(nomadEval PRIVATE -DDLL_EVAL_EXPORTS)
 endif()
 
 # Algos
@@ -525,6 +536,9 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/Algos/PSDMads
         ${CMAKE_CURRENT_SOURCE_DIR}/Algos/SSDMads>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+endif()
+if (WIN32)
+    target_compile_definitions(nomadAlgos PRIVATE -DDLL_ALGO_EXPORTS)
 endif()
 
 #

--- a/src/Cache/CacheBase.cpp
+++ b/src/Cache/CacheBase.cpp
@@ -79,7 +79,7 @@ void NOMAD::CacheBase::init()
 }
 
 
-bool isTrue(const NOMAD::EvalPoint& evalPoint __attribute__((unused)))
+bool isTrue(const NOMAD::EvalPoint& NOMAD_UNUSED(evalPoint))
 {
     return true;
 }

--- a/src/Cache/CacheBase.hpp
+++ b/src/Cache/CacheBase.hpp
@@ -56,6 +56,7 @@
 #include <atomic>       // For atomic
 #include <vector>
 
+#include "../nomad_platform.hpp"
 #include "../Eval/EvalPoint.hpp"
 #include "../Param/CacheParameters.hpp"
 
@@ -88,7 +89,7 @@ protected:
      *   It could be a set (CacheSet), an unordered_set (CacheSet with
      *   precompiler option USE_UNORDEREDSET) map, multimap, SQL database, etc.
     */
-    static std::atomic<size_t> _nbCacheHits;
+    DLL_EVAL_API static std::atomic<size_t> _nbCacheHits;
 
     /// Name of the file to write or read cache to.
     /**
@@ -107,7 +108,7 @@ protected:
     /// The cache parameters used by the cache
     std::shared_ptr<CacheParameters> _cacheParams;
 
-    static std::unique_ptr<CacheBase> _single; ///< The singleton
+    DLL_EVAL_API static std::unique_ptr<CacheBase> _single; ///< The singleton
 
     /// Dimension of the points in the cache.
     /**
@@ -208,11 +209,12 @@ public:
        each EvalPoint may be processed in place. It is not needed
        to remove it from the cache, process it, and then put it back.
      */
-    virtual void processOnAllPoints(void (*func)(EvalPoint&) __attribute__((unused)))
+    typedef void (*EvalFunc_t)(EvalPoint&);
+    virtual void processOnAllPoints(EvalFunc_t NOMAD_UNUSED(func))
     {
         std::cerr << "Warning: processOnAllPoints is not implemented for this type of cache." << std::endl;
     }
-    virtual void processOnAllPoints(void (*func)(EvalPoint&) __attribute__((unused)), const int mainThreadNum __attribute__((unused)))
+    virtual void processOnAllPoints(EvalFunc_t NOMAD_UNUSED(func), const int NOMAD_UNUSED(mainThreadNum))
     {
         std::cerr << "Warning: processOnAllPoints is not implemented for this type of cache." << std::endl;
     }

--- a/src/Eval/Barrier.cpp
+++ b/src/Eval/Barrier.cpp
@@ -155,7 +155,7 @@ void NOMAD::Barrier::checkCache()
     {
         NOMAD::CacheBase::getInstance();
     }
-    catch (NOMAD::Exception &e)
+    catch (NOMAD::Exception & /*e*/)
     {
         throw NOMAD::Exception(__FILE__, __LINE__,
                                "Cache must be instantiated before initializing Barrier.");

--- a/src/Eval/ComparePriority.hpp
+++ b/src/Eval/ComparePriority.hpp
@@ -54,6 +54,7 @@
 #ifndef __NOMAD400_COMPAREPRIORITY__
 #define __NOMAD400_COMPAREPRIORITY__
 
+#include "../nomad_platform.hpp"
 #include "../Eval/EvalQueuePoint.hpp"
 #include "../Math/Direction.hpp"
 #include "../Math/RandomPickup.hpp"
@@ -72,7 +73,7 @@ private:
     std::string _name;  ///< Method name, useful for information or debugging
 
 public:
-    virtual bool comp(EvalQueuePointPtr& point1 __attribute__((unused)), EvalQueuePointPtr& point2 __attribute__((unused))) const
+    virtual bool comp(EvalQueuePointPtr& NOMAD_UNUSED(point1), EvalQueuePointPtr& NOMAD_UNUSED(point2)) const
     {
         return false;
     }

--- a/src/Eval/ComputeSuccessType.hpp
+++ b/src/Eval/ComputeSuccessType.hpp
@@ -54,6 +54,7 @@
 #ifndef __NOMAD400_COMPUTESUCCESSTYPE__
 #define __NOMAD400_COMPUTESUCCESSTYPE__
 
+#include "../nomad_platform.hpp"
 #include "../Eval/EvalPoint.hpp"
 
 
@@ -124,7 +125,7 @@ public:
      */
     static SuccessType computeSuccessTypePhaseOne(const EvalPointPtr& evalPoint1,
                                               const EvalPointPtr& evalPoint2,
-                                              const Double& hMax __attribute__((unused)));
+                                              const Double& NOMAD_UNUSED(hMax));
 
 private:
     /// Helper for Constructor.

--- a/src/Eval/Evaluator.cpp
+++ b/src/Eval/Evaluator.cpp
@@ -48,9 +48,25 @@
 #include "../Util/fileutils.hpp"
 #include <fstream>  // For ofstream
 #include <stdio.h>  // For popen
+#ifndef _WIN32
+#include <unistd.h> // for getpid
+#else
+#include <process.h>
+#define getpid _getpid
+#define popen  _popen
+#define pclose _pclose
+#endif
 
 // Initialize statics
 std::vector<std::string> NOMAD::Evaluator::_tmpFiles = std::vector<std::string>();
+
+namespace {
+    // the cleanup of temporary files at program shutdown needs to remain with this
+    // translation unit to guarantee the correct destruction order
+    struct TmpFilesCleanup {
+        ~TmpFilesCleanup() { NOMAD::Evaluator::removeTmpFiles(); }
+    } _TmpFilesCleanup;
+}
 
 //
 // Constructor

--- a/src/Eval/EvaluatorControl.cpp
+++ b/src/Eval/EvaluatorControl.cpp
@@ -52,7 +52,7 @@
 #include "../Type/EvalSortType.hpp"
 #include "../Util/AllStopReasons.hpp"
 #include "../Util/Clock.hpp"
-#include <unistd.h> // For usleep
+#include "../Util/MicroSleep.hpp"
 
 /*------------------------*/
 /* Class EvaluatorControl */
@@ -117,9 +117,6 @@ void NOMAD::EvaluatorControl::destroy()
             }
         }
     }
-
-    // Remove tmp files, clean up after ourselves
-    NOMAD::Evaluator::removeTmpFiles();
 
 #ifdef _OPENMP
     omp_destroy_lock(&_evalQueueLock);
@@ -645,7 +642,7 @@ bool NOMAD::EvaluatorControl::popBlock(NOMAD::BlockForEval &block)
             modelBlockSize = _evalContGlobalParams->getAttributeValue<size_t>("MODEL_MAX_BLOCK_SIZE");
             gotBlockSize = true;
         }
-        catch (NOMAD::ParameterToBeChecked &e)
+        catch (NOMAD::ParameterToBeChecked &/*e*/)
         {
             // While will loop - Retry
         }
@@ -1198,7 +1195,7 @@ bool NOMAD::EvaluatorControl::reachedMaxEval() const
         maxEval      = _evalContGlobalParams->getAttributeValue<size_t>("MAX_EVAL");
         maxBlockEval = _evalContGlobalParams->getAttributeValue<size_t>("MAX_BLOCK_EVAL");
     }
-    catch (NOMAD::ParameterToBeChecked &e)
+    catch (NOMAD::ParameterToBeChecked &/*e*/)
     {
         // Early out. Ignore the test: return false.
         return false;

--- a/src/Eval/EvcMainThreadInfo.cpp
+++ b/src/Eval/EvcMainThreadInfo.cpp
@@ -44,10 +44,9 @@
 /*  You can find information on the NOMAD software at www.gerad.ca/nomad           */
 /*---------------------------------------------------------------------------------*/
 
-#include <unistd.h> // For usleep
-
 #include "../Eval/EvcMainThreadInfo.hpp"
 #include "../Output/OutputQueue.hpp"
+#include "../Util/MicroSleep.hpp"
 
 /*-------------------------*/
 /* Class EvcMainThreadInfo */
@@ -103,7 +102,7 @@ bool NOMAD::EvcMainThreadInfo::getOpportunisticEval() const
         {
             return _evalContParams->getAttributeValue<bool>("EVAL_OPPORTUNISTIC");
         }
-        catch (NOMAD::ParameterToBeChecked &e)
+        catch (NOMAD::ParameterToBeChecked &/*e*/)
         {
             // Exception due to parameters being in process of checkAndComply().
             // While will loop - Retry
@@ -127,7 +126,7 @@ bool NOMAD::EvcMainThreadInfo::getUseCache() const
         {
             return _evalContParams->getAttributeValue<bool>("EVAL_USE_CACHE");
         }
-        catch (NOMAD::ParameterToBeChecked &e)
+        catch (NOMAD::ParameterToBeChecked &/*e*/)
         {
             // Exception due to parameters being in process of checkAndComply().
             // While will loop - Retry
@@ -151,7 +150,7 @@ size_t NOMAD::EvcMainThreadInfo::getMaxBbEvalInSubproblem() const
         {
             return _evalContParams->getAttributeValue<size_t>("SUBPROBLEM_MAX_BB_EVAL");
         }
-        catch (NOMAD::ParameterToBeChecked &e)
+        catch (NOMAD::ParameterToBeChecked &/*e*/)
         {
             // Exception due to parameters being in process of checkAndComply().
             // While will loop - Retry

--- a/src/Math/ArrayOfDouble.hpp
+++ b/src/Math/ArrayOfDouble.hpp
@@ -55,6 +55,8 @@
 #define __NOMAD400_ARRAYOFDOUBLE__
 
 #include <numeric>
+
+#include "../nomad_platform.hpp"
 #include "../Math/Double.hpp"
 #include "../Util/ArrayOfString.hpp"
 
@@ -68,8 +70,8 @@ class ArrayOfDouble {
 
 public:
 
-    static const std::string pStart; ///< Static variable used for array delimitation.
-    static const std::string pEnd; ///< Static variable used for array delimitation.
+    DLL_UTIL_API static const std::string pStart; ///< Static variable used for array delimitation.
+    DLL_UTIL_API static const std::string pEnd; ///< Static variable used for array delimitation.
 
 protected:
     /*---------*/

--- a/src/Math/Double.cpp
+++ b/src/Math/Double.cpp
@@ -50,6 +50,7 @@
  \date   2010-04-02
  \see    Double.hpp
  */
+#include <cctype>   // for toupper
 #include <iomanip>  // For std::setprecision
 #include "../Math/Double.hpp"
 #include "../Util/defines.hpp"
@@ -788,11 +789,11 @@ std::size_t NOMAD::Double::nbDecimals( ) const
     }
 
     NOMAD::Double rem( _value );
-    int dec = std::floor(log10(rem.todouble()));
+    int dec = (int)std::floor(log10(rem.todouble()));
     rem -= pow(10, dec);
     while (rem._value >= _epsilon)
     {
-        dec = std::floor(log10(rem.todouble()));
+        dec = (int)std::floor(log10(rem.todouble()));
         rem -= pow(10, dec);
     }
     if (dec > 0)

--- a/src/Math/Double.hpp
+++ b/src/Math/Double.hpp
@@ -56,6 +56,7 @@
 
 #include <cmath>
 
+#include "../nomad_platform.hpp"
 #include "../Util/defines.hpp"
 #include "../Util/Exception.hpp"
 #include "../Util/utils.hpp"
@@ -75,9 +76,9 @@
         bool          _defined; ///< \c true if the number has a defined value.
 
         // \todo Make these local static objects
-        static double      _epsilon;    ///< Desired precision on comparisons.
-        static std::string _infStr;     ///< Infinity string.
-        static std::string _undefStr;   ///< Undefined value string.
+        DLL_UTIL_API static double      _epsilon;    ///< Desired precision on comparisons.
+        DLL_UTIL_API static std::string _infStr;     ///< Infinity string.
+        DLL_UTIL_API static std::string _undefStr;   ///< Undefined value string.
 
     public:
 

--- a/src/Math/Point.hpp
+++ b/src/Math/Point.hpp
@@ -55,6 +55,7 @@
 #define __NOMAD400_POINT__
 
 #include <numeric>
+#include "../nomad_platform.hpp"
 #include "../Math/ArrayOfDouble.hpp"
 #include "../Math/Direction.hpp"
 
@@ -135,7 +136,7 @@ public:
      * Ends up to lexicographic order. Not useful. Throw an exception.
      * Ignore warning about unused variable point
      */
-    bool operator<(const Point &point __attribute__((unused))) const
+    bool operator<(const Point &NOMAD_UNUSED(point)) const
     {
         throw Exception(__FILE__,__LINE__,"Error: Attempting to use lexicographical order on a Point.");
     }

--- a/src/Math/RNG.hpp
+++ b/src/Math/RNG.hpp
@@ -54,6 +54,7 @@
 #ifndef __NOMAD400_RNG__
 #define __NOMAD400_RNG__
 
+#include "../nomad_platform.hpp"
 #include "../Util/defines.hpp"
 #include "../Util/Exception.hpp"
 
@@ -166,12 +167,10 @@ public:
 
 private:
 
-    static uint32_t x_def, y_def, z_def;    ///< Initial values for the random number generator
-    static uint32_t _x, _y, _z;             ///< Current values for the random number generator
+    DLL_UTIL_API static uint32_t x_def, y_def, z_def;    ///< Initial values for the random number generator
+    DLL_UTIL_API static uint32_t _x, _y, _z;             ///< Current values for the random number generator
 
-    static int _s;
-
-
+    DLL_UTIL_API static int _s;
 };
 
 #include "../nomad_nsend.hpp"

--- a/src/Output/OutputDirectToFile.cpp
+++ b/src/Output/OutputDirectToFile.cpp
@@ -90,18 +90,21 @@ NOMAD::OutputDirectToFile::~OutputDirectToFile()
 // Access to singleton
 std::unique_ptr<NOMAD::OutputDirectToFile>& NOMAD::OutputDirectToFile::getInstance()
 {
-#ifdef _OPENMP
-    // Lock queue before creating singleton
-    omp_set_lock(&_s_output_lock);
-#endif
     if (nullptr == _single)
     {
-        _single = std::unique_ptr<OutputDirectToFile> (new OutputDirectToFile()) ;
+#ifdef _OPENMP
+#pragma omp critical(initODFLock)
+        if (nullptr == _single)
+        {
+        omp_init_lock(&_s_output_lock);
+#endif
+            _single = std::unique_ptr<OutputDirectToFile> (new OutputDirectToFile()) ;
+#ifdef _OPENMP
+#pragma omp flush
+        } // end critical section initODFLock
+#endif // _OPENMP
     }
 
-#ifdef _OPENMP
-    omp_unset_lock(&_s_output_lock);
-#endif // _OPENMP
     return _single;
 }
 

--- a/src/Param/EvaluatorControlGlobalParameters.cpp
+++ b/src/Param/EvaluatorControlGlobalParameters.cpp
@@ -141,7 +141,7 @@ void NOMAD::EvaluatorControlGlobalParameters::checkAndComply(const std::shared_p
                 }
             }
 
-            std::cerr << "All variables are granular. MAX_EVAL is set to " << new_max_eval << " to prevent algorithm from circling around best solution indefinetely" << std::endl;
+            std::cerr << "All variables are granular. MAX_EVAL is set to " << new_max_eval << " to prevent algorithm from circling around best solution indefinitely" << std::endl;
 
             setAttributeValue("MAX_EVAL",new_max_eval);
         }

--- a/src/Param/Parameters.cpp
+++ b/src/Param/Parameters.cpp
@@ -54,7 +54,11 @@
 #include "../Type/SgtelibModelFeasibilityType.hpp"
 #include "../Type/SgtelibModelFormulationType.hpp"
 #include "../Util/fileutils.hpp"
-
+#ifdef _WIN32
+#include <io.h>    // For _access
+#define access _access
+#define R_OK 04
+#endif
 
 // The deep copy of parameters. Used only by derived object that implemented the copy constructor and copy assignment
 void NOMAD::Parameters::copyParameters(const Parameters& params)

--- a/src/Param/Parameters.hpp
+++ b/src/Param/Parameters.hpp
@@ -53,6 +53,7 @@
 #include <typeindex>
 #include <typeinfo>
 
+#include "../nomad_platform.hpp"
 #include "../Math/Double.hpp"
 #include "../Math/Point.hpp"
 #include "../Math/ArrayOfPoint.hpp"
@@ -146,7 +147,7 @@ protected:
     /*---------*/
     /* Members */
     /*---------*/
-    static ParameterEntries _paramEntries; ///< The set of entries obtained when reading a parameter file.
+    DLL_UTIL_API static ParameterEntries _paramEntries; ///< The set of entries obtained when reading a parameter file.
 
     std::string _typeName; ///< The type of parameters: ex. Problem, Run
 
@@ -162,7 +163,7 @@ protected:
      Map of attribute names and type name as string.
      Static to the class.
      */
-    static std::map<std::string,std::string> _typeOfAttributes;
+    DLL_UTIL_API static std::map<std::string,std::string> _typeOfAttributes;
 
     /// Constructors
     /**

--- a/src/Param/RunParameters.cpp
+++ b/src/Param/RunParameters.cpp
@@ -291,7 +291,7 @@ void NOMAD::RunParameters::checkAndComply(
         bool nbMadsSubproblemSetByUser = true;
         if (nbMadsSubproblem == INF_SIZE_T)
         {
-            nbMadsSubproblem = std::round(n/nbVariablesInSubproblem)+1; // Add an additional mads for the pollster
+            nbMadsSubproblem = (size_t)std::round(n/nbVariablesInSubproblem)+1; // Add an additional mads for the pollster
             nbMadsSubproblemSetByUser = false;
         }
         if (useAlgoPSDMads)

--- a/src/Util/AllStopReasons.hpp
+++ b/src/Util/AllStopReasons.hpp
@@ -46,6 +46,7 @@
 #ifndef __NOMAD400_ALLSTOPREASONS__
 #define __NOMAD400_ALLSTOPREASONS__
 
+#include "../nomad_platform.hpp"
 #include "../Util/StopReason.hpp"
 
 #include "../nomad_nsbegin.hpp"
@@ -74,8 +75,8 @@ public:
     {}
 
 private:
-    static StopReason<BaseStopType> _baseStopReason; ///< A single base stop reason is considered for NOMAD.
-    static StopReason<EvalGlobalStopType> _evalGlobalStopReason; ///< An eval stop reason valable for the whole of NOMAD.
+    DLL_UTIL_API static StopReason<BaseStopType> _baseStopReason; ///< A single base stop reason is considered for NOMAD.
+    DLL_UTIL_API static StopReason<EvalGlobalStopType> _evalGlobalStopReason; ///< An eval stop reason valable for the whole of NOMAD.
     StopReason<IterStopType> _iterStopReason; ///< An iteration stop reason.
 
 public:

--- a/src/Util/ArrayOfString.cpp
+++ b/src/Util/ArrayOfString.cpp
@@ -50,6 +50,7 @@
  \date   February 2018
  \see    ArrayOfString.hpp
  */
+#include <algorithm>
 #include <sstream>
 
 #include "../Util/ArrayOfString.hpp"

--- a/src/Util/Clock.hpp
+++ b/src/Util/Clock.hpp
@@ -55,20 +55,8 @@
 
 #include <ctime>
 
+#include "../nomad_platform.hpp"
 #include "../nomad_nsbegin.hpp"
-
-#ifdef _MSC_VER
-#pragma warning(disable:4275)
-#pragma warning(disable:4251)
-#ifdef DLL_EXPORTS
-#define DLL_API __declspec(dllexport)
-#else
-#define DLL_API __declspec(dllimport)
-#endif
-#else
-#define DLL_API
-#endif
-
 
 /// Clock class.
 /**
@@ -79,7 +67,7 @@
  std::cout << "elapsed CPU time  = " << Clock::getCPUTime()  << std::endl;
  \endcode
  */
-class DLL_API Clock {
+class DLL_UTIL_API Clock {
 
 private:
 

--- a/src/Util/fileutils.cpp
+++ b/src/Util/fileutils.cpp
@@ -52,6 +52,10 @@
  */
 #include "../Util/fileutils.hpp"
 #include "../Util/utils.hpp"
+#ifdef _WIN32
+#include <direct.h>     // for getcwd
+#define getcwd _getcwd
+#endif
 
 /*-----------------------------------------------------------------*/
 /*              check if a file exists and is executable           */
@@ -95,15 +99,10 @@ bool NOMAD::checkWriteFile(const std::string &filename)
 std::string NOMAD::curdir()
 {
     char dirbuff[1024];
-#ifdef WINDOWS
-#include <direct.h>
-    _getcwd(dirbuff, 1024);
-#else
     if (nullptr == getcwd(dirbuff, 1024))
     {
         std::cerr << "Warning: Could not get current directory" << std::endl;
     }
-#endif
     std::string dir(dirbuff);
 
     return dir;

--- a/src/Util/utils.cpp
+++ b/src/Util/utils.cpp
@@ -51,6 +51,7 @@
  \see    utils.hpp
  */
 #include <algorithm>    // for for_each
+#include <cctype>       // for toupper
 #ifdef _OPENMP
 #include <omp.h>
 #endif // _OPENMP

--- a/src/nomad_platform.hpp
+++ b/src/nomad_platform.hpp
@@ -1,0 +1,34 @@
+#ifdef _WIN32
+#define NOMAD_UNUSED(x)
+#define NOMAD_PRETTY_FUNCTION __FUNCSIG__
+#else
+#define NOMAD_UNUSED(x) x __attribute__((unused))
+#define NOMAD_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
+#ifdef _WIN32
+#pragma warning(disable:4275)
+#pragma warning(disable:4251)
+#endif
+
+#ifdef _WIN32
+#ifdef DLL_UTIL_EXPORTS
+# define DLL_UTIL_API __declspec(dllexport)
+#else
+# define DLL_UTIL_API __declspec(dllimport)
+#endif
+#ifdef DLL_EVAL_EXPORTS
+# define DLL_EVAL_API __declspec(dllexport)
+#else
+# define DLL_EVAL_API __declspec(dllimport)
+#endif
+#ifdef DLL_ALGO_EXPORTS
+# define DLL_ALGO_API __declspec(dllexport)
+#else
+# define DLL_ALGO_API __declspec(dllimport)
+#endif
+#else
+#define DLL_UTIL_API
+#define DLL_EVAL_API
+#define DLL_ALGO_API
+#endif


### PR DESCRIPTION
This PR ports NOMAD4 to MS Windows. A large number of files are touched, but there are only a couple of themes of recurring changes, several of which are also relevant on Linux/Mac. I've put them in one PR as they are all needed to work on Windows, but if you prefer to have the general fixes separately, I can split them up.

Needed on all platforms:
- OpenMP fixes: in creation of singletons in `OutputDirectToFile.cpp`, `OutputQueue.cpp`, and `CacheSet.cpp`, the OMP lock is set before it is initialized (in the case of the first, it is actually never initialized). Further, the assignment of the `unique_ptr` is not fenced and in the case of `CacheSet.cpp`, the thrown exception will leave the lock in a locked state. In `Algorithm.cpp`, instances init/destroy the class-static lock, so if two instances co-exist, they both init/destroy it twice, and can also set a destroyed lock. I've replaced this with `critical` sections, under the assumption that performance wasn't the main reason for having a static lock here.
- Offload order fix: `Evaluator::removeTmpFiles()` is called in `EvaluatorControl.cpp` (`destroy`) on program shutdown, but that relies on a static variable in `Evaluator.cpp` (`Evaluator::_tmpFiles`). The destruction order of statics is not guaranteed across translation units, and as it happens on Windows, `removeTmpFiles()` is called after `Evaluator::_tmpFiles` has been destroyed. By putting the destruction in `Evaluator.cpp`, order is guaranteed (this assumes that `destroy` is only called on application shutdown).
- Missing include files: several standard headers were missing for use of standard functions.

Windows-specific
- `CMakeLists.txt` updates to build on Windows, including the usual suspect of `dllimport`, `dllexport`, but also setting the `SUFFIX` of the library examples to `""`, to prevent ".exe.exe". The function symbols are automatically exported using a standard cmake macro (`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`). Pre-processor macro's in the source code are used so export data members, as appropriate for each of the Nomad libraries (since two of them both import and export, each needed their own macro to disambiguate).
- New files `nomad_platform.hpp` and `MicroSleep.hpp`. The former to capture platform differences in macro's, the latter has an implementation of `usleep` using standard C++.
- Macro-replacements of `__attribute__` (doesn't exist on Windows) and `__PRETTY_FUNCTION__` (named differently).
- Windows-specific POSIX name fixes (underscores).
- Explicit type casts to silence warnings (should have shown up on other platforms as well).
- Comment out unused variables to prevent warnings.