### PR TITLE
Update the link of the Artifacts

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -187,7 +187,7 @@ cmake --install build/debug (for *OSX* and *Linux*)
 
 BINARIES:
 Nomad libraries are available in a Julia package for some plateforms at 
-https://github.com/JuliaBinaryWrappers/NOMAD_jll.jl
+https://github.com/JuliaBinaryWrappers/NOMAD_jll.jl/tree/main
 
 
 EXAMPLES OF OPTIMIZATION:


### PR DESCRIPTION
We compiled `nomad` 4.2.0 today with Yggdrasil and I remarked that the artifact was pushed on the `main` branch.