### PR TITLE
Test NOMAD on Apple M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-13-0-release-amd64
+  image: freebsd-13-1-release-amd64
 task:
   name: FreeBSD
   dependencies_script: |
@@ -22,5 +22,31 @@ task:
     export PATH=`pwd`/build/bin:$PATH
     echo $PATH
     ln -s /usr/local/bin/bash /bin/bash
+    cd build
+    ctest -C Release --parallel 8
+
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-monterey-base:latest
+task:
+  name: MacOS M1
+  dependencies_script: |
+    brew install cmake
+  configure_script: |
+    mkdir instdir
+    mkdir build
+    cd build
+    cmake \
+      -DTEST_OPENMP=OFF \
+      -DBUILD_INTERFACE_C=ON \
+      -DBUILD_TESTS=ON \
+      -DCMAKE_INSTALL_PREFIX=../instdir \
+      ..
+  build_script: |
+    cmake --build build --parallel 8 --config Release
+  install_script: |
+    cmake --install build --config Release
+  test_script: |
+    export PATH=`pwd`/build/bin:$PATH
+    echo $PATH
     cd build
     ctest -C Release --parallel 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           }
         - {
             name: "Windows -- MinGW", artifact: "Windows-MinGW.tar.xz",
-            os: windows-latest-mingw,
+            os: windows-latest,
             build_type: "Release", cc: "x86_64-w64-mingw32-gcc", cxx: "x86_64-w64-mingw32-g++"
           }
         - {


### PR DESCRIPTION
CirrusCI was updated and it supports Apple M1 for open source softwares now.