### PR TITLE
Addressing issue #121

### DIFF
--- a/interfaces/PyNomad/PyNomad.pyx
+++ b/interfaces/PyNomad/PyNomad.pyx
@@ -186,15 +186,16 @@ def optimize(fBB, pX0, pLB, pUB, params, fSurrogate=None):
     cdef double fReturn = float("inf")
     cdef double hReturn = float("inf")
     xReturn = []
+    eParams = []
 
     cdef size_t nbParams = len(params)
     for i in range(nbParams):
-         params[i] = params[i].encode(u"ascii")
+         eParams.append(params[i].encode(u"ascii"))
 
     if fSurrogate is None:
         runStatus = runNomad(cb, cbL, <void*> fBB, <vector[double]&> pX0,
                          <vector[double]&> pLB, <vector[double]&> pUB,
-                         <vector[string]&> params,
+                         <vector[string]&> eParams,
                          uFeas.c_ep_ptr,
                          uInfeas.c_ep_ptr,
                          nbEvals, nbIters)
@@ -202,7 +203,7 @@ def optimize(fBB, pX0, pLB, pUB, params, fSurrogate=None):
         runStatus = runNomad(cb, cbL, <void*> fBB,  <void*> fSurrogate,
                          <vector[double]&> pX0,
                          <vector[double]&> pLB, <vector[double]&> pUB,
-                         <vector[string]&> params,
+                         <vector[string]&> eParams,
                          uFeas.c_ep_ptr,
                          uInfeas.c_ep_ptr,
                          nbEvals, nbIters)


### PR DESCRIPTION
- The way `PyNomad.optimize` handles parameters has been found problematic in #53 and consequently fixed with https://github.com/bbopt/nomad/pull/80. 
- The commit d7c1b52f0add9cf51cedc89c188e9a822be69594 has introduced a regression: the handling of parameters has been incorrectly reverted.
- This has been recently reported in #121.

This patch fixes the behavior for the current version of PyNomad once again. Would it be possible to merge this patch into the private development branch of NOMAD as well to prevent further regressions?