### PR TITLE
Fixed std::binary_function deprecation.

### DIFF
--- a/src/Param/Parameters.hpp
+++ b/src/Param/Parameters.hpp
@@ -69,7 +69,7 @@
 typedef std::shared_ptr<Attribute> SPtrAtt;
 
 /// Comparator of shared_ptr<Attribute>
-struct lessThanAttribute : public std::binary_function<SPtrAtt, SPtrAtt, bool>
+struct lessThanAttribute 
 {
     bool operator()(SPtrAtt lhs, SPtrAtt rhs) const
     {


### PR DESCRIPTION
With C++11 the [std::binary_function](https://en.cppreference.com/w/cpp/utility/functional/binary_function) was deprecated and removed with C++17. This one-line change suppresses the warnings compilers (such as GCC) produce. Tested on Linux (GCC) and Windows (MinGW).