### PR TITLE
Test problem warning

### DIFF
--- a/examples/basic/batch/PythonBB/bb.py
+++ b/examples/basic/batch/PythonBB/bb.py
@@ -4,7 +4,7 @@ import re
 input_file_name=sys.argv[1]
 with open(input_file_name,'r') as openfile:
     line = openfile.read().strip()
-    X = re.sub('\s+',' ',line).strip().split()
+    X = re.sub(r'\s+',' ',line).strip().split()
     openfile.close()
 
 # Standard output is grabbed by Nomad evaluator


### PR DESCRIPTION
Updated string as "raw string" to avoid output warning SyntaxWarning: invalid escape sequence '\s'. Found this issue when switching from python 3.8 to python 3.13.1 