### PR TITLE
Fix bug for PSDMads with EB constraint and x0 infeasible

### DIFF
--- a/src/Algos/Mads/MadsInitialization.cpp
+++ b/src/Algos/Mads/MadsInitialization.cpp
@@ -270,7 +270,8 @@ bool NOMAD::MadsInitialization::eval_x0s()
         }
 
         // Case where x0 evaluation does not satisfy an extreme barrier constraint
-        if (nullptr == _barrier->getCurrentIncumbentFeas() && nullptr == _barrier->getCurrentIncumbentInf())
+        // For PSD-Mads, we do not want to conduct PhaseOne on a single thread.
+        if (nullptr == _barrier->getCurrentIncumbentFeas() && nullptr == _barrier->getCurrentIncumbentInf() && !_isUsedForPSDMads /*No phase one for psd mads*/)
         {
             // Run PhaseOne, which has its own Mads.
             // Then continue regular Mads with an initial feasible point (if found by phaseOne).

--- a/src/Algos/Mads/MadsInitialization.hpp
+++ b/src/Algos/Mads/MadsInitialization.hpp
@@ -72,6 +72,7 @@ protected:
     bool _barrierInitializedFromCache;
     bool _isUsedForDMultiMads;
     bool _isUsedForDiscoMads;
+    bool _isUsedForPSDMads;
 
 public:
     /// Constructor
@@ -79,12 +80,13 @@ public:
      \param parentStep                   The parent of this step -- \b IN.
      \param barrierInitializedFromCache  Flag to initialize barrier from cache or not -- \b IN.
      */
-    explicit MadsInitialization(const Step* parentStep, bool barrierInitializedFromCache=true, bool isUsedForDMultiMads=false, bool isUsedForDiscoMads=false)
+    explicit MadsInitialization(const Step* parentStep, bool barrierInitializedFromCache=true, bool isUsedForDMultiMads=false, bool isUsedForDiscoMads=false,bool isUsedForPSDMads=false)
       : Initialization(parentStep),
         _initialMesh(nullptr),
         _barrierInitializedFromCache(barrierInitializedFromCache),
         _isUsedForDMultiMads(isUsedForDMultiMads),
-        _isUsedForDiscoMads(isUsedForDiscoMads)
+        _isUsedForDiscoMads(isUsedForDiscoMads),
+        _isUsedForPSDMads(isUsedForPSDMads)
     {
         init();
     }

--- a/src/Algos/PSDMads/PSDMads.cpp
+++ b/src/Algos/PSDMads/PSDMads.cpp
@@ -86,8 +86,8 @@ void NOMAD::PSDMads::init(const std::vector<NOMAD::EvaluatorPtr> &evaluators,
     }
     OUTPUT_INFO_END
 
-    // Instantiate MadsInitialization member
-    _initialization = std::make_unique<NOMAD::MadsInitialization>(this);
+    // Instantiate MadsInitialization member (special for PSDMads)
+    _initialization = std::make_unique<NOMAD::MadsInitialization>(this, true, false, false , true /*true: for PSDMads*/);
 
     // Initialize all the main threads we will need.
     // The main threads will be the ones with thread numbers 0-(nbMainThreads-1).

--- a/src/Eval/BarrierBase.cpp
+++ b/src/Eval/BarrierBase.cpp
@@ -133,6 +133,10 @@ std::vector<NOMAD::EvalPoint> NOMAD::BarrierBase::getAllPoints() const
     {
         allPoints.push_back(*p);
     }
+    for (const auto & p: _xInfOut )
+    {
+        allPoints.push_back(*p);
+    }
     return allPoints;
 }
 
@@ -143,6 +147,7 @@ std::vector<NOMAD::EvalPointPtr> NOMAD::BarrierBase::getAllPointsPtr() const
     allPoints.reserve(_xFeas.size() + _xInf.size()); // preallocate memory
     allPoints.insert(allPoints.end(), _xFeas.begin(), _xFeas.end());
     allPoints.insert(allPoints.end(), _xInf.begin(), _xInf.end());
+    allPoints.insert(allPoints.end(), _xInfOut.begin(), _xInfOut.end());
 
     return allPoints;
 }

--- a/src/Eval/BarrierBase.hpp
+++ b/src/Eval/BarrierBase.hpp
@@ -59,6 +59,7 @@ protected:
 
     std::vector<EvalPointPtr> _xFeas;  ///< Current feasible incumbent solutions
     std::vector<EvalPointPtr> _xInf;   ///< Current infeasible barrier points (contains infeasible incumbents) with h<=hMax
+    std::vector<EvalPointPtr> _xInfOut; ///< Current infeasible points not in barrier because h=INF. Used for initialization only when EB constraint is not verified.
     
     std::vector<EvalPointPtr> _xIncFeas;   ///< Current feasible incumbent solutions. Can be a subset of _xFeas but for now, xIncFeas and xFeas are the same
     std::vector<EvalPointPtr> _xIncInf;   ///< Current infeasible incumbent solutions (subset of _xInf if it is defined). For now, we consider a vector (maybe DMultiMads needs it)

--- a/src/Eval/ProgressiveBarrier.cpp
+++ b/src/Eval/ProgressiveBarrier.cpp
@@ -104,17 +104,69 @@ void NOMAD::ProgressiveBarrier::init(const NOMAD::Point& fixedVariable,
 void NOMAD::ProgressiveBarrier::init(const NOMAD::Point& fixedVariable,
                           const std::vector<NOMAD::EvalPoint>& evalPointList)
 {
-
+    
+    if (_xFeas.empty() && _xInf.empty() && _xInfOut.empty())
+    {
+        // Put the least infeasible point(s) in _xInfOut
+        // This is the case where we have no feasible point and no infeasible point because of EB constraint -> h=inf
+        // Let's change the computation of h for PB and find the least infeasible point(s)
+        NOMAD::Double hLim= NOMAD::INF;
+        for (const auto &evalPoint : evalPointList)
+        {
+            NOMAD::Eval* eval = evalPoint.getEval(NOMAD::EvalType::BB);
+            if (nullptr == eval || NOMAD::EvalStatusType::EVAL_OK != eval->getEvalStatus())
+            {
+                continue;
+            }
+            if (eval->isFeasible(defaultFHComputeTypeS))
+            {
+                continue;
+            }
+            // Let's change bb output type EB to EB
+            auto bbot = eval->getBBOutputTypeList();
+            std::replace_if(bbot.begin(), bbot.end(),
+                            [](NOMAD::BBOutputType t){ return t == NOMAD::BBOutputType::EB; }, // Predicate
+                            NOMAD::BBOutputType::PB // New value
+                            );
+            eval->setBBOutputTypeList(bbot);
+            
+            // Get infeasibility using default computation
+            NOMAD::Double h = eval->getH(defaultFHComputeTypeS);
+            if (!h.isDefined() || h == NOMAD::INF)
+            {
+                continue;
+            }
+            // Must be in the subspace defined byFixedVariable
+            if (!evalPoint.hasFixed(fixedVariable))
+            {
+                continue;
+            }
+            
+            // Keep the least infeasible point(s)
+            if (h <= hLim)
+            {
+                if (h < hLim)
+                {
+                    _xInfOut.clear();
+                }
+                NOMAD::EvalPointPtr evalPointPtr = std::make_shared<NOMAD::EvalPoint>(evalPoint);
+                _xInfOut.push_back(evalPointPtr);
+            }
+        }
+    }
+    
     // Constructor's call to update should not update ref best points.
     updateWithPoints(evalPointList, true, true /*true update infeasible incumbent and hmax*/ );
 
     // Check: xIncFeas or xIncInf could be non-evaluated, but not both.
+    OUTPUT_DEBUG_START
+    std::string s;
     auto xIncFeas = getCurrentIncumbentFeas();
     auto xIncInf = getCurrentIncumbentInf();
     if (   (nullptr == xIncFeas || nullptr == xIncFeas->getEval(_computeType.evalType))
         && (nullptr == xIncInf  || nullptr == xIncInf->getEval(_computeType.evalType)))
     {
-        std::string s = "Barrier constructor: no xIncFeas and xIncInf  properly defined. This may cause problems. \n";
+        s = "Barrier constructor: no xIncFeas and xIncInf  properly defined. This may cause problems. \n";
         if (nullptr != xIncFeas)
         {
             s += "There are " + std::to_string(_xIncFeas.size()) + " feasible incumbents, the first one is:\n";
@@ -126,6 +178,9 @@ void NOMAD::ProgressiveBarrier::init(const NOMAD::Point& fixedVariable,
             s += xIncInf->displayAll(NOMAD::defaultFHComputeTypeS);
         }
     }
+    NOMAD::OutputQueue::Add(s, NOMAD::OutputLevel::LEVEL_DEBUG);
+    NOMAD::OutputQueue::Flush();
+    OUTPUT_DEBUG_END
 
     checkHMax();
 }


### PR DESCRIPTION
MadsInitialization should not start PhaseOne search on a single thread, let this task to the Subproblems. Need to keep the infeasible point (EB) in the barrier if _xInf and _xFeas are empty.